### PR TITLE
fix save data when nirs.aux is an array of struct

### DIFF
--- a/savesnirf.m
+++ b/savesnirf.m
@@ -84,11 +84,13 @@ if (~isempty(outfile))
             fields = fieldnames(force1d);
             for i = 1:length(fields)
                 for j = 1:length(force1d.(fields{i}))
-                    if (isfield(data.nirs.(fields{i}), force1d.(fields{i}){j}))
-                        if (iscell(data.nirs.(fields{i}).(force1d.(fields{i}){j})))
-                            data.nirs.(fields{i}).(force1d.(fields{i}){j}) = cell2mat(data.nirs.(fields{i}).(force1d.(fields{i}){j}));
+                    for k = 1:length(data.nirs.(fields{i}))
+                        if (isfield(data.nirs.(fields{i})(k), force1d.(fields{i}){j}))
+                            if (iscell(data.nirs.(fields{i})(k).(force1d.(fields{i}){j})))
+                                data.nirs.(fields{i})(k).(force1d.(fields{i}){j}) = cell2mat(data.nirs.(fields{i})(k).(force1d.(fields{i}){j}));
+                            end
+                            data.nirs.(fields{i})(k).(force1d.(fields{i}){j}) = timeseries(data.nirs.(fields{i})(k).(force1d.(fields{i}){j})(:).');
                         end
-                        data.nirs.(fields{i}).(force1d.(fields{i}){j}) = timeseries(data.nirs.(fields{i}).(force1d.(fields{i}){j})(:).');
                     end
                 end
             end


### PR DESCRIPTION

Hello, 

According to the specifications, nirs.aux can be an array of structures. This would cause the script to fail. 
 https://github.com/fNIRS/snirf/blob/v1.1/snirf_specification.md#nirsiauxj


### Example of data: 
https://drive.google.com/file/d/1BNnk7w3NDx6rGKQaBzXVYE5hRfUlBH5V/view?usp=share_link

### Code: 

```matlab
data = load('data.mat').data;
savesnirf(data, 'test.snirf')

```


### Error without the fix: 

```text

Error using iscell
Too many input arguments.

Error in savesnirf (line 88)
                        if (iscell(data.nirs.(fields{i}).(force1d.(fields{i}){j})))

```


### Validator: 

With this fix, the genereted file pass the validator: 
```python
from snirf import validateSnirf
result = validateSnirf(r'/Users/edelaire1/Desktop/tmp/sub-01_task-tapping_run-01.snirf')
result.display() 
```

```
<snirf.pysnirf2.ValidationResult object at 0x1111c0ec0> is_valid True

Found 534 OK      (hidden)
Found 599 INFO    (hidden)
Found 0 WARNING
Found 0 FATAL  


File is VALID
```


Thanks
Edouard
